### PR TITLE
Added translations for Brazilian Portuguese

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -7,7 +7,7 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry combineaccessrules="false" kind="src" path="/apple_stubs"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/apple_stubs"/>
 	<classpathentry kind="lib" path="libraries/trove-3.0.3.jar" sourcepath="libraries/trove-3.0.3-src.jar"/>
 	<classpathentry kind="output" path="build"/>
 </classpath>

--- a/src/com/trollworks/toolkit/collections/QuadTree.java
+++ b/src/com/trollworks/toolkit/collections/QuadTree.java
@@ -525,6 +525,7 @@ public class QuadTree<T extends Bounds> {
 		@Localize(locale = "ru", value = "Объекты должны иметь ширину и высоту больше нуля.")
 		@Localize(locale = "de", value = "Objekte müssen eine Höhe und Breite größer als Null haben.")
 		@Localize(locale = "es", value = "El objeto debe tener anchura y altura mayor que cero.")
+		@Localize(locale = "pt-BR", value = "Objetos precisam ter a largura e altura maiores que zero.")
 		private static String	MUST_HAVE_SIZE_GREATER_THAN_ZERO;
 		private int				mX;
 		private int				mY;

--- a/src/com/trollworks/toolkit/expression/ArgumentTokenizer.java
+++ b/src/com/trollworks/toolkit/expression/ArgumentTokenizer.java
@@ -19,8 +19,10 @@ import java.util.Enumeration;
 
 public class ArgumentTokenizer implements Enumeration<String> {
 	@Localize("Invalid operand: ")
+	@Localize(locale = "pt-BR", value = "Operando inválido")
 	private static String	INVALID_OPERAND;
 	@Localize("Invalid argument: ")
+	@Localize(locale = "pt-BR", value = "Argumento inválido")
 	private static String	INVALID_ARGUMENT;
 
 	static {

--- a/src/com/trollworks/toolkit/expression/Evaluator.java
+++ b/src/com/trollworks/toolkit/expression/Evaluator.java
@@ -52,16 +52,22 @@ import java.util.Map;
 /** A simple expression evaluator. */
 public class Evaluator {
 	@Localize("Consecutive unary operators are not allowed (index=%d)")
+	@Localize(locale = "pt-BR", value = "Operadores unários consecutivos não são permitidos (índice=%d)")
 	private static String	CONSECUTIVE_UNARY_OPS;
 	@Localize("Function not closed")
+	@Localize(locale = "pt-BR", value = "Função não fechada")
 	private static String	FUNCTION_NOT_CLOSED;
 	@Localize("Function not defined: %s")
+	@Localize(locale = "pt-BR", value = "Função não definida: %s")
 	private static String	FUNCTION_NOT_DEFINED;
 	@Localize("Expression is invalid")
+	@Localize(locale = "pt-BR", value = "A expressão é inválida")
 	private static String	INVALID_EXPRESSION;
 	@Localize("Invalid variable at index %d")
+	@Localize(locale = "pt-BR", value = "Variável inválido no índice %d")
 	private static String	INVALID_VARIABLE;
 	@Localize("Unable to resolve variable $%s")
+	@Localize(locale = "pt-BR", value = "Incapaz de resolver a variável $%s")
 	private static String	UNABLE_TO_RESOLVE;
 
 	static {

--- a/src/com/trollworks/toolkit/expression/ExpressionTree.java
+++ b/src/com/trollworks/toolkit/expression/ExpressionTree.java
@@ -17,6 +17,7 @@ import com.trollworks.toolkit.utility.Localization;
 
 class ExpressionTree {
 	@Localize("Expression is invalid")
+	@Localize(locale = "pt-BR", value = "A expressão é inválida")
 	private static String INVALID_EXPRESSION;
 
 	static {

--- a/src/com/trollworks/toolkit/expression/function/DisplayDice.java
+++ b/src/com/trollworks/toolkit/expression/function/DisplayDice.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 public class DisplayDice implements ExpressionFunction {
 	@Localize("Invalid dice specification: %s")
+	@Localize(locale = "pt-BR", value = "Especificação de dados inválida: %s")
 	private static String INVALID_DICE_SPEC;
 
 	static {

--- a/src/com/trollworks/toolkit/expression/function/Max.java
+++ b/src/com/trollworks/toolkit/expression/function/Max.java
@@ -19,6 +19,7 @@ import com.trollworks.toolkit.utility.Localization;
 
 public class Max implements ExpressionFunction {
 	@Localize("Two numeric arguments are required")
+	@Localize(locale = "pt-BR", value = "Dois argumentos numéricos são requeridos")
 	private static String INVALID_ARGUMENTS;
 
 	static {

--- a/src/com/trollworks/toolkit/expression/function/Min.java
+++ b/src/com/trollworks/toolkit/expression/function/Min.java
@@ -19,6 +19,7 @@ import com.trollworks.toolkit.utility.Localization;
 
 public class Min implements ExpressionFunction {
 	@Localize("Two numeric arguments are required")
+	@Localize(locale = "pt-BR", value = "Dois argumentos numéricos são requeridos")
 	private static String INVALID_ARGUMENTS;
 
 	static {

--- a/src/com/trollworks/toolkit/expression/function/Roll.java
+++ b/src/com/trollworks/toolkit/expression/function/Roll.java
@@ -19,6 +19,7 @@ import com.trollworks.toolkit.utility.Localization;
 
 public class Roll implements ExpressionFunction {
 	@Localize("Invalid dice specification: %s")
+	@Localize(locale = "pt-BR", value = "Especificação de dados inválida: %s")
 	private static String INVALID_DICE_SPEC;
 
 	static {

--- a/src/com/trollworks/toolkit/io/SafeFileUpdater.java
+++ b/src/com/trollworks/toolkit/io/SafeFileUpdater.java
@@ -26,21 +26,25 @@ import java.util.Map;
  */
 public class SafeFileUpdater {
 	@Localize("No transaction in progress.")
+	@Localize(locale = "pt-BR", value = "Nenhuma transação em progresso")
 	@Localize(locale = "ru", value = "Нет действий в обработке")
 	@Localize(locale = "de", value = "Keine Transaktion wird ausgeführt.")
 	@Localize(locale = "es", value = "No hay transaciones en progreso.")
 	private static String	NO_TRANSACTION_IN_PROGRESS;
 	@Localize("Unable to swap files.")
+	@Localize(locale = "pt-BR", value = "Incapaz de trocar os arquivos")
 	@Localize(locale = "ru", value = "Невозможно поменять файлы.")
 	@Localize(locale = "de", value = "Kann Dateien nicht auswechseln.")
 	@Localize(locale = "es", value = "Imposible crear ficheros de intercambio.")
 	private static String	FILE_SWAP_FAILED;
 	@Localize("\"file\" may not be null.")
+	@Localize(locale = "pt-BR", value = "\"arquivo\" não pode ser nulo")
 	@Localize(locale = "ru", value = "\"файл\" не может быть пустым.")
 	@Localize(locale = "de", value = "\"file\" darf nicht null sein.")
 	@Localize(locale = "es", value = "\"archivo\" no puede ser nulo.")
 	private static String	MAY_NOT_BE_NULL;
 	@Localize("\"file\" may not refer to a directory.")
+	@Localize(locale = "pt-BR", value = "\"arquivo\" não pode se referir a um diretório")
 	@Localize(locale = "ru", value = "\"файл\" не может ссылаться на папку.")
 	@Localize(locale = "de", value = "\"file\" darf kein Verzeichnis sein.")
 	@Localize(locale = "es", value = "\"archivo\" no puede ser un directorio.")

--- a/src/com/trollworks/toolkit/ui/GraphicsUtilities.java
+++ b/src/com/trollworks/toolkit/ui/GraphicsUtilities.java
@@ -41,6 +41,7 @@ import javax.swing.UIManager;
 
 /** Provides general graphics settings and manipulation. */
 public class GraphicsUtilities {
+	@Localize(locale = "pt-BR", value = "Não há nenhum dispositivo gráfico válido")
 	@Localize("There is no valid graphics display.")
 	@Localize(locale = "ru", value = "Нет доступного графического дисплея")
 	@Localize(locale = "de", value = "Kein gültiges Grafikausgabegerät gefunden.")

--- a/src/com/trollworks/toolkit/ui/UpdateChecker.java
+++ b/src/com/trollworks/toolkit/ui/UpdateChecker.java
@@ -35,26 +35,31 @@ import javax.swing.JOptionPane;
 /** Provides a background check for updates. */
 public class UpdateChecker implements Runnable {
 	@Localize("Checking for updates\u2026")
+	@Localize(locale = "pt-BR", value = "Checando por atualizações\u2026")
 	@Localize(locale = "ru", value = "Проверка обновлений\u2026")
 	@Localize(locale = "de", value = "Prüfe auf neue Version\u2026")
 	@Localize(locale = "es", value = "Comprobando actulizaciones\u2026")
 	private static String	CHECKING;
 	@Localize("You have the most recent version")
+	@Localize(locale = "pt-BR", value = "Você tem a versão mais recente")
 	@Localize(locale = "ru", value = "У вас самая последняя версия")
 	@Localize(locale = "de", value = "Programm ist aktuell")
 	@Localize(locale = "es", value = "Ya tienes la versión más reciente")
 	private static String	UP_TO_DATE;
 	@Localize("A new version is available")
+	@Localize(locale = "pt-BR", value = "Uma nova versão está disponível")
 	@Localize(locale = "ru", value = "Доступна новая версия")
 	@Localize(locale = "de", value = "Eine neue Version ist verfügbar")
 	@Localize(locale = "es", value = "Hay una nueva versión disponible")
 	private static String	OUT_OF_DATE;
 	@Localize("Update")
+	@Localize(locale = "pt-BR", value = "Atualize")
 	@Localize(locale = "ru", value = "Обновить")
 	@Localize(locale = "de", value = "Aktualisieren")
 	@Localize(locale = "es", value = "Actualizar")
 	private static String	UPDATE_TITLE;
 	@Localize("Ignore")
+	@Localize(locale = "pt-BR", value = "Ignore")
 	@Localize(locale = "ru", value = "Игнорировать")
 	@Localize(locale = "de", value = "Ignorieren")
 	@Localize(locale = "es", value = "Ignorar")

--- a/src/com/trollworks/toolkit/utility/BundleInfo.java
+++ b/src/com/trollworks/toolkit/utility/BundleInfo.java
@@ -24,11 +24,13 @@ import java.util.jar.Attributes;
 /** Provides information for a bundle of code. */
 public class BundleInfo {
 	@Localize("Development")
+	@Localize(locale = "pt-BR", value = "Desenvolvimento")
 	@Localize(locale = "ru", value = "Разработка")
 	@Localize(locale = "de", value = "Entwicklung")
 	@Localize(locale = "es", value = "Desarrollo")
 	private static String	DEVELOPMENT;
 	@Localize("Unspecified")
+	@Localize(locale = "pt-BR", value = "Não especificado")
 	@Localize(locale = "ru", value = "Не указан")
 	@Localize(locale = "de", value = "Nicht angegeben")
 	@Localize(locale = "es", value = "No especificado")
@@ -36,11 +38,13 @@ public class BundleInfo {
 	@Localize("%s %s\n%s\n%s")
 	private static String	APP_BANNER_FORMAT;
 	@Localize("Copyright \u00A9 %s by %s")
+	@Localize(locale = "pt-BR", value = "Direitos autorais \u00A9 %s por %s")
 	@Localize(locale = "ru", value = "Авторское право \u00A9 %s от %s")
 	@Localize(locale = "de", value = "Copyright \u00A9 %2$s, %1$s")
 	@Localize(locale = "es", value = "Copyright \u00A9 %2$s, %1$s")
 	private static String	COPYRIGHT_FORMAT;
 	@Localize("All rights reserved")
+	@Localize(locale = "pt-BR", value = "Todos os direitos reservados")
 	@Localize(locale = "ru", value = "Все права защищены")
 	@Localize(locale = "de", value = "Alle Rechte vorbehalten")
 	@Localize(locale = "es", value = "Reservados todos los derechos")

--- a/src/com/trollworks/toolkit/utility/FileType.java
+++ b/src/com/trollworks/toolkit/utility/FileType.java
@@ -27,16 +27,22 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 /** Describes a file. */
 public class FileType {
 	@Localize("HTML Files")
+	@Localize(locale = "pt-BR", value = "Arquivos HTML")
 	private static String	HTML_FILES;
 	@Localize("PDF Files")
+	@Localize(locale = "pt-BR", value = "Arquivos PDF")
 	private static String	PDF_FILES;
 	@Localize("PNG Files")
+	@Localize(locale = "pt-BR", value = "Arquivos PNG")
 	private static String	PNG_FILES;
 	@Localize("GIF Files")
+	@Localize(locale = "pt-BR", value = "Arquivos GIF")
 	private static String	GIF_FILES;
 	@Localize("JPEG Files")
+	@Localize(locale = "pt-BR", value = "Arquivos JPEG")
 	private static String	JPEG_FILES;
 	@Localize("Image Files")
+	@Localize(locale = "pt-BR", value = "Arquivos de imagens")
 	private static String	IMAGE_FILES;
 
 	static {

--- a/src/com/trollworks/toolkit/utility/Model.java
+++ b/src/com/trollworks/toolkit/utility/Model.java
@@ -29,16 +29,19 @@ import javax.xml.stream.XMLStreamException;
 /** The abstract base model object, responsible for providing basic i/o. */
 public abstract class Model implements Cloneable {
 	@Localize("Expected tag \"{0}\", but found \"{1}\".")
+	@Localize(locale = "pt-BR", value = "A tag esperada era \"{0}\", mas foi encontrada \"{1}\"")
 	@Localize(locale = "ru", value = "Ожидаемый тег \"{0}\", но найден \"{1}\".")
 	@Localize(locale = "de", value = "Tag \"{0}\" erwartet, aber \"{1}\" erhalten.")
 	@Localize(locale = "es", value = "Se esperaba la etiqueta \"{0}\", pero se encontró \"{1}\".")
 	private static String	INVALID_ROOT_TAG;
 	@Localize("The tag \"{0}\" is from an older version and cannot be loaded.")
+	@Localize(locale = "pt-BR", value = "A tag \"{0}\" é de uma versão antiga e não pode ser carregada")
 	@Localize(locale = "ru", value = "Тег \"{0}\" относится к более старой версии и не может быть загружен.")
 	@Localize(locale = "de", value = "Das Tag \"{0}\" ist von einer älteren Version und kann nicht geladen werden.")
 	@Localize(locale = "es", value = "La etiqueta \"{0}\" proviene de una versión anterior y no puede abrirse")
 	private static String	TOO_OLD;
 	@Localize("The tag \"{0}\" is from a newer version and cannot be loaded.")
+	@Localize(locale = "pt-BR", value = "A tag \"{0}\" é de uma versão mais recente e não pode ser carregada")
 	@Localize(locale = "ru", value = "Тег \"{0}\" относится к более новой версии и не может быть загружен.")
 	@Localize(locale = "de", value = "Das Tag \"{0}\" ist von einer neueren Version und kann nicht geladen werden.")
 	@Localize(locale = "es", value = "La etiqueta \"{0}\" proviene de una versión posterior y no puede abrirse")

--- a/src/com/trollworks/toolkit/utility/NewerDataFileVersionException.java
+++ b/src/com/trollworks/toolkit/utility/NewerDataFileVersionException.java
@@ -19,6 +19,7 @@ import java.text.MessageFormat;
 /** An exception for data files that are too new to be loaded. */
 public class NewerDataFileVersionException extends IOException {
 	@Localize("The data file is from a newer version of {0} and cannot be loaded.")
+	@Localize(locale = "pt-BR", value = "O arquivos de dados é de uma versão mais recente {0} e não pode ser carregado.")
 	@Localize(locale = "ru", value = "Файл с данными относится к более поздней версии {0} и не может быть загружен.")
 	@Localize(locale = "de", value = "Die Datendatei ist von einer neueren Version von {0} und kann nicht geladen werden.")
 	@Localize(locale = "es", value = "El archivo se ha creado con una versión más reciente {0} y no puede abrirse")

--- a/src/com/trollworks/toolkit/utility/Preferences.java
+++ b/src/com/trollworks/toolkit/utility/Preferences.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 /** Provides the implementation of preferences. */
 public class Preferences {
 	@Localize("Global preferences have not been initialized yet!")
+	@Localize(locale = "pt-BR", value = "As preferências globais ainda não foram inicializadas!")
 	@Localize(locale = "ru", value = "Глобальные парметры ещё не были инициализированы!")
 	@Localize(locale = "de", value = "Globale Einstellungen wurden noch nicht initialisiert!")
 	@Localize(locale = "es", value = "Las preferencias generales no se han iniciallizado todavia")

--- a/src/com/trollworks/toolkit/utility/Version.java
+++ b/src/com/trollworks/toolkit/utility/Version.java
@@ -18,11 +18,13 @@ import java.util.Calendar;
 /** Provides support for various forms of version numbers. */
 public class Version {
 	@Localize("Invalid version format")
+	@Localize(locale = "pt-BR", value = "Formato de versão inválido")
 	@Localize(locale = "ru", value = "Недопустимая верия формата")
 	@Localize(locale = "de", value = "Ungültiges Format der Versionsnumer")
 	@Localize(locale = "es", value = "Formato de versión no válido")
 	private static String	INVALID_VERSION_FORMAT;
 	@Localize("Built on %1$tB %1$te, %1$tY at %1$tr")
+	@Localize(locale = "pt-BR", value = "Compilado no %1$tB %1$te, %1$tY em %1$tr")
 	@Localize(locale = "ru", value = "Сборка программы от %1$tB %1$te, %1$tY в %1$tr")
 	@Localize(locale = "de", value = "Erstellt am %1$te. %1$tB %1$tY um %1$tT")
 	@Localize(locale = "es", value = "Compilado el %1$tB %1$te, %1$tY at %1$tr")

--- a/src/com/trollworks/toolkit/utility/VersionException.java
+++ b/src/com/trollworks/toolkit/utility/VersionException.java
@@ -18,11 +18,13 @@ import java.io.IOException;
 /** An exception for data files that are too old or new to be loaded. */
 public class VersionException extends IOException {
 	@Localize("The file is from an older version and cannot be loaded.")
+	@Localize(locale = "pt-BR", value = "O arquivo é de uma versão mais antiga e não pode ser carregado.")
 	@Localize(locale = "ru", value = "Файл более старой версии не может быть загружен.")
 	@Localize(locale = "de", value = "Die Datei ist von einer älteren Version und kann nicht geladen werden.")
 	@Localize(locale = "es", value = "El archivo es creó con una versión anterior y no puede abrirse.")
 	private static String	TOO_OLD;
 	@Localize("The file is from a newer version and cannot be loaded.")
+	@Localize(locale = "pt-BR", value = "O arquivo é de uma versão mais nova e não pode ser carregado.")
 	@Localize(locale = "ru", value = "Файл более новой версии не может быть загружен.")
 	@Localize(locale = "de", value = "Die Datei ist von einer neueren Version und kann nicht geladen werden.")
 	@Localize(locale = "es", value = "El archivo es creó con una versión posterior y no puede abrirse.")


### PR DESCRIPTION
Added translations for Brazilian Portuguese to the toolkit.
Configured project to use UT-8 (Project Properties -> Resource -> Text file encoding -> Other = UTF-8) to enable Brazilian Portuguese characters properly.