### PR TITLE
Added more support for tooltips

### DIFF
--- a/src/com/trollworks/toolkit/ui/widget/outline/Row.java
+++ b/src/com/trollworks/toolkit/ui/widget/outline/Row.java
@@ -333,4 +333,21 @@ public abstract class Row {
         }
         return depth;
     }
+
+    /**
+     * return Should this row show a tooltip? Subclasses will override to be able to force tooltips
+     * to appear
+     */
+    public boolean alwaysShowToolTip(Column column) {
+        return false;
+    }
+
+    /**
+     * return String to display as tooltip. Default to the column's data. Subclasses may override to
+     * provide specialized tooltips.
+     */
+    public String getToolTip(Column column) {
+        return getDataAsText(column);
+    }
+
 }

--- a/src/com/trollworks/toolkit/ui/widget/outline/TextCell.java
+++ b/src/com/trollworks/toolkit/ui/widget/outline/TextCell.java
@@ -226,7 +226,10 @@ public class TextCell implements Cell {
     protected String getData(Row row, Column column, boolean nullOK) {
         if (row != null) {
             String text = row.getDataAsText(column);
-            return text == null ? nullOK ? null : "" : text; //$NON-NLS-1$
+            if (text == null) {
+                return nullOK ? null : ""; //$NON-NLS-1$
+            }
+            return text;
         }
         return column.toString();
     }
@@ -286,7 +289,10 @@ public class TextCell implements Cell {
     protected String getToolTip(Row row, Column column, boolean nullOK) {
         if (row != null) {
             String text = row.getToolTip(column);
-            return text == null ? nullOK ? null : "" : text; //$NON-NLS-1$
+            if (text == null) {
+                return nullOK ? null : ""; //$NON-NLS-1$
+            }
+            return text;
         }
         return column.toString();
     }

--- a/src/com/trollworks/toolkit/ui/widget/outline/TextCell.java
+++ b/src/com/trollworks/toolkit/ui/widget/outline/TextCell.java
@@ -260,8 +260,8 @@ public class TextCell implements Cell {
     @Override
     public String getToolTipText(Outline outline, MouseEvent event, Rectangle bounds, Row row, Column column) {
         Scale scale = Scale.get(outline);
-        if (getPreferredWidth(outline, row, column) - scale.scale(H_MARGIN) > column.getWidth() - scale.scale(row.getOwner().getIndentWidth(row, column))) {
-            return getData(row, column, true);
+        if (row.alwaysShowToolTip(column) || getPreferredWidth(outline, row, column) - scale.scale(H_MARGIN) > column.getWidth() - scale.scale(row.getOwner().getIndentWidth(row, column))) {
+            return getToolTip(row, column, true);
         }
         return null;
     }
@@ -275,4 +275,20 @@ public class TextCell implements Cell {
     public void mouseClicked(MouseEvent event, Rectangle bounds, Row row, Column column) {
         // Does nothing
     }
+
+    /**
+     * @param row    The row.
+     * @param column The column.
+     * @param nullOK <code>true</code> if <code>null</code> may be returned.
+     * @return The tooltip of this cell as a string.
+     */
+    @SuppressWarnings("static-method")
+    protected String getToolTip(Row row, Column column, boolean nullOK) {
+        if (row != null) {
+            String text = row.getToolTip(column);
+            return text == null ? nullOK ? null : "" : text; //$NON-NLS-1$
+        }
+        return column.toString();
+    }
+
 }


### PR DESCRIPTION
#1 (in a series).   This is the base code for the tooltip support.   It is a non-destructive addition of functionality that is required to support the tooltip logic in 'gcs' (which will be coming in a future pull request).

Rows can now indicate if they want to "always show a tooltip" (regardless of size limitations), which defaults to false.

TextCells will check this method to determine if they should show a tooltip, and if so, they will request the "tooltip" information from the row (instead of the generic "getData").   This allows subclasses to define what represents a tooltip to them.

This code can be included as is, and it will not change any current functionality (since the default behavior for returning a "toolitp" is to just to "getData").

I re-cloned from your repository, and then force pushed to my github, so there should not be a lot of extraneous commits.



